### PR TITLE
Issue #24 Show a window to select the pull secret if not configured

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
 ## Build crc
     steps:
     - checkout
+    - run: sudo defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES
+    - run: rm ~/.ssh/id_rsa || true
+    - run: for ip in $(dig @1.1.1.1 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
     - run:
         name: Build project
         command: ./build.sh

--- a/CodeReady Containers.xcodeproj/project.pbxproj
+++ b/CodeReady Containers.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		5594643F23879B6700BC99CA /* Handlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5594643E23879B6700BC99CA /* Handlers.swift */; };
 		55946441238D332600BC99CA /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55946440238D332600BC99CA /* UserNotifications.framework */; };
 		55D67AC72385DEE600F56917 /* DaemonCommander.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D67AC62385DEE600F56917 /* DaemonCommander.swift */; };
+		55F8D913252313A900B5E045 /* pullSecretStoryBoard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 55F8D912252313A900B5E045 /* pullSecretStoryBoard.storyboard */; };
+		55F8D9162523147F00B5E045 /* PullSecretWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F8D9152523147F00B5E045 /* PullSecretWindowController.swift */; };
+		55F8D91925231C2200B5E045 /* PullSecretViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F8D91825231C2200B5E045 /* PullSecretViewController.swift */; };
 		A3390174251DF71D00415FD9 /* Socket in Frameworks */ = {isa = PBXBuildFile; productRef = A3390173251DF71D00415FD9 /* Socket */; };
 /* End PBXBuildFile section */
 
@@ -38,6 +41,9 @@
 		5594643E23879B6700BC99CA /* Handlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handlers.swift; sourceTree = "<group>"; };
 		55946440238D332600BC99CA /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		55D67AC62385DEE600F56917 /* DaemonCommander.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonCommander.swift; sourceTree = "<group>"; };
+		55F8D912252313A900B5E045 /* pullSecretStoryBoard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = pullSecretStoryBoard.storyboard; sourceTree = "<group>"; };
+		55F8D9152523147F00B5E045 /* PullSecretWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullSecretWindowController.swift; sourceTree = "<group>"; };
+		55F8D91825231C2200B5E045 /* PullSecretViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullSecretViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +106,7 @@
 		556DAAEF237AB11600885463 /* CodeReady Containers */ = {
 			isa = PBXGroup;
 			children = (
+				55F8D9112523138000B5E045 /* PullSecretPicker */,
 				556DAB00237AB16200885463 /* CodeReady Containers.entitlements */,
 				5590C40A23D18102000DFF54 /* ExportOptions.plist */,
 				556DAAF0237AB11600885463 /* AppDelegate.swift */,
@@ -112,6 +119,16 @@
 				556DAAF9237AB11600885463 /* Info.plist */,
 			);
 			path = "CodeReady Containers";
+			sourceTree = "<group>";
+		};
+		55F8D9112523138000B5E045 /* PullSecretPicker */ = {
+			isa = PBXGroup;
+			children = (
+				55F8D912252313A900B5E045 /* pullSecretStoryBoard.storyboard */,
+				55F8D9152523147F00B5E045 /* PullSecretWindowController.swift */,
+				55F8D91825231C2200B5E045 /* PullSecretViewController.swift */,
+			);
+			path = PullSecretPicker;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -185,6 +202,7 @@
 			files = (
 				556DAAF5237AB11600885463 /* Assets.xcassets in Resources */,
 				556DAAF8237AB11600885463 /* Main.storyboard in Resources */,
+				55F8D913252313A900B5E045 /* pullSecretStoryBoard.storyboard in Resources */,
 				5590C40B23D18102000DFF54 /* ExportOptions.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -201,9 +219,11 @@
 				55168E1A23962545005D4232 /* Helpers.swift in Sources */,
 				5594643F23879B6700BC99CA /* Handlers.swift in Sources */,
 				556DAAF3237AB11600885463 /* DetailedStatusViewController.swift in Sources */,
+				55F8D91925231C2200B5E045 /* PullSecretViewController.swift in Sources */,
 				55D67AC72385DEE600F56917 /* DaemonCommander.swift in Sources */,
 				55168E1723955F3F005D4232 /* HyperLinkTextField.swift in Sources */,
 				556DAAF1237AB11600885463 /* AppDelegate.swift in Sources */,
+				55F8D9162523147F00B5E045 /* PullSecretWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CodeReady Containers/DaemonCommander/DaemonCommander.swift
+++ b/CodeReady Containers/DaemonCommander/DaemonCommander.swift
@@ -86,3 +86,16 @@ func SendCommandToDaemon(command: Request) -> Data? {
     }
     return "Failed".data(using: .utf8)
 }
+
+func SendCommandToDaemon(command: ConfigGetRequest) -> Data? {
+    do {
+        let req = try JSONEncoder().encode(command)
+        let daemonConnection = DaemonCommander(sockPath: socketPath.path)
+        daemonConnection.connectToDaemon()
+        daemonConnection.sendCommand(command: req)
+        return daemonConnection.readResponse()
+    } catch let error {
+        print(error.localizedDescription)
+    }
+    return "Failed".data(using: .utf8)
+}

--- a/CodeReady Containers/Helpers/Helpers.swift
+++ b/CodeReady Containers/Helpers/Helpers.swift
@@ -117,3 +117,25 @@ func folderSize(folderPath:URL) -> Int64 {
     }
     return size
 }
+
+func showFilePicker(msg: String, txtField: NSTextField) {
+    let dialog = NSOpenPanel()
+
+    dialog.title                   = msg
+    dialog.showsResizeIndicator    = false
+    dialog.showsHiddenFiles        = false
+    dialog.canChooseDirectories    = false
+    dialog.canCreateDirectories    = false
+    dialog.allowsMultipleSelection = false
+
+    if (dialog.runModal() == NSApplication.ModalResponse.OK) {
+        let filePath = dialog.url // Pathname of the file
+        
+        if (filePath != nil) {
+            txtField.setValue(filePath?.path, forKey: "stringValue")
+            return
+        }
+    }
+    // User clicked cancel
+    return
+}

--- a/CodeReady Containers/PullSecretPicker/PullSecretViewController.swift
+++ b/CodeReady Containers/PullSecretPicker/PullSecretViewController.swift
@@ -1,0 +1,58 @@
+//
+//  PullSecretViewController.swift
+//  CodeReady Containers
+//
+//  Created by Anjan Nath on 29/09/20.
+//  Copyright © 2020 Red Hat. All rights reserved.
+//
+
+import Cocoa
+
+class PullSecretViewController: NSViewController, NSTextFieldDelegate {
+
+    @IBOutlet weak var pullSecretFilePath: NSTextField!
+    @IBOutlet weak var helpLabel: NSTextField!
+    
+    let helpString: String = "Please visit cloud.redhat.com to obtain Pull Secret"
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do view setup here.
+        self.preferredContentSize = NSMakeSize(self.view.frame.size.width, self.view.frame.height)
+    }
+    
+    override func viewDidAppear() {
+        view.window?.title = self.title!
+        view.window?.level = .floating
+    }
+    
+    @IBAction func browseButtonClicked(_ sender: Any) {
+        // show the filepicker
+        // set the path of the file as filepath in the textfield
+        showFilePicker(msg: "Select Pull Secret File", txtField: self.pullSecretFilePath)
+    }
+    
+    @IBAction func okButtonClicked(_ sender: Any) {
+        // check if the textfield is empty
+        // if not communicate the filepath back to app delegate
+        if self.pullSecretFilePath.stringValue == "" {
+            // show help string to get pull secret
+            let attributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: NSColor.red,
+                .font: NSFont(name: "Helvetica Neue Italic", size: 12) as Any
+            ]
+            let styledString = NSAttributedString(string: self.helpString, attributes: attributes)
+            self.helpLabel.attributedStringValue = styledString
+        } else {
+            self.view.window?.close()
+            let path = self.pullSecretFilePath.stringValue
+            DispatchQueue.global(qos: .userInteractive).async {
+                HandleStart(pullSecretPath: path)
+            }
+        }
+    }
+    
+    func controlTextDidBeginEditing(_ obj: Notification) {
+        self.helpLabel.attributedStringValue = NSAttributedString(string: "")
+    }
+}

--- a/CodeReady Containers/PullSecretPicker/PullSecretWindowController.swift
+++ b/CodeReady Containers/PullSecretPicker/PullSecretWindowController.swift
@@ -1,0 +1,23 @@
+//
+//  PullSecretWindowController.swift
+//  CodeReady Containers
+//
+//  Created by Anjan Nath on 29/09/20.
+//  Copyright © 2020 Red Hat. All rights reserved.
+//
+
+import Cocoa
+
+class PullSecretWindowController: NSWindowController {
+    class func loadFromStoryBoard() -> PullSecretWindowController? {
+        let controller = NSStoryboard(name: "pullSecretStoryBoard", bundle: nil).instantiateController(withIdentifier: "PullSecretWindowController") as! PullSecretWindowController
+        return controller
+    }
+    
+    override func windowDidLoad() {
+        super.windowDidLoad()
+    
+        // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
+    }
+
+}

--- a/CodeReady Containers/PullSecretPicker/pullSecretStoryBoard.storyboard
+++ b/CodeReady Containers/PullSecretPicker/pullSecretStoryBoard.storyboard
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="UZP-iD-tBs">
+            <objects>
+                <windowController storyboardIdentifier="PullSecretWindowController" id="Axx-Po-YKL" customClass="PullSecretWindowController" customModule="CodeReady_Containers" customModuleProvider="target" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="" animationBehavior="default" id="6J1-tL-yey">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
+                        <rect key="contentRect" x="109" y="1412" width="392" height="270"/>
+                        <rect key="screenRect" x="-185" y="1050" width="1920" height="1177"/>
+                        <view key="contentView" id="i5l-eb-YVh">
+                            <rect key="frame" x="0.0" y="0.0" width="392" height="270"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </view>
+                        <connections>
+                            <outlet property="delegate" destination="Axx-Po-YKL" id="tme-tm-hBE"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="0oN-MP-yQV" kind="relationship" relationship="window.shadowedContentViewController" id="Mm2-Nw-gEz"/>
+                    </connections>
+                </windowController>
+                <customObject id="I5Y-Mm-1yA" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-144" y="-21"/>
+        </scene>
+        <!--Select Pull Secret-->
+        <scene sceneID="bhG-D8-ayG">
+            <objects>
+                <viewController title="Select Pull Secret" id="0oN-MP-yQV" customClass="PullSecretViewController" customModule="CodeReady_Containers" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="ZRY-7T-CBv">
+                        <rect key="frame" x="0.0" y="0.0" width="433" height="140"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5NV-kJ-gXd">
+                                <rect key="frame" x="18" y="104" width="279" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Please provide Pull Secret to start the Cluster" id="jZu-Wz-fdk">
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Q2-yM-gAN">
+                                <rect key="frame" x="334" y="52" width="85" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Browse" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="thD-cf-LQB">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="browseButtonClicked:" target="0oN-MP-yQV" id="hco-0q-wjO"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I4V-U3-oe3">
+                                <rect key="frame" x="349" y="13" width="59" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hnA-o5-bBQ">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                    <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="okButtonClicked:" target="0oN-MP-yQV" id="cVb-h3-NIK"/>
+                                </connections>
+                            </button>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bMZ-AI-PyB">
+                                <rect key="frame" x="18" y="35" width="329" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" id="e24-kf-3uZ">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TJC-4b-IPA">
+                                <rect key="frame" x="20" y="59" width="301" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Z0e-ZL-HqA">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="0oN-MP-yQV" id="HU8-br-30a"/>
+                                </connections>
+                            </textField>
+                        </subviews>
+                    </view>
+                    <connections>
+                        <outlet property="helpLabel" destination="bMZ-AI-PyB" id="wjV-lI-C7v"/>
+                        <outlet property="pullSecretFilePath" destination="TJC-4b-IPA" id="Iz1-I2-F8b"/>
+                    </connections>
+                </viewController>
+                <customObject id="giK-VG-DuW" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-123.5" y="354"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
This will use the pull-secret as an argument to start and not save
it in crc configs

Depends on https://github.com/code-ready/crc/pull/1561

## Testing
1. Make sure `pull-secret-file` is unset in `crc`
2. Remove the already running tray and start the tray from this PR's artifact
3. Click on start, when prompted to select pull secret, click on browse and select the pull secret file
4. Follow along with `tail -f ~/.crc/crcd.log`

<img width="439" alt="Screenshot 2020-10-02 at 8 24 08 AM" src="https://user-images.githubusercontent.com/8885742/94884305-c14d5200-048a-11eb-9450-b4abb2dda0db.png">
<img width="435" alt="Screenshot 2020-10-02 at 8 24 57 AM" src="https://user-images.githubusercontent.com/8885742/94884310-c4484280-048a-11eb-8d07-efa3711cddce.png">

