### PR TITLE
Correct the coding key for autostart tray

### DIFF
--- a/CodeReady Containers/DaemonCommander/Handlers.swift
+++ b/CodeReady Containers/DaemonCommander/Handlers.swift
@@ -122,7 +122,7 @@ struct CrcConfigs: Codable {
         case diskSize = "disk-size"
         case networkMode = "network-mode"
         case consentTelemetry = "consent-telemetry"
-        case autostartTray = "auto-start-tray"
+        case autostartTray = "autostart-tray"
         case skipCheckBundleExtracted = "skip-check-bundle-extracted"
         case skipCheckHostsFilePermissions = "skip-check-hosts-file-permissions"
         case skipCheckHyperkitDriver = "skip-check-hyperkit-driver"

--- a/CodeReady Containers/Info.plist
+++ b/CodeReady Containers/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
- bump the version to `1.0.1`