### PR TITLE
Refresh the status of the cluster every 5s

### DIFF
--- a/CodeReady Containers/AppDelegate.swift
+++ b/CodeReady Containers/AppDelegate.swift
@@ -211,9 +211,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
     
     func menuWillOpen(_ menu: NSMenu) {
-        DispatchQueue.global(qos: .background).async {
-            self.refreshStatusAndMenu()
-        }
     }
     
     @objc func refreshStatusAndMenu() {

--- a/CodeReady Containers/AppDelegate.swift
+++ b/CodeReady Containers/AppDelegate.swift
@@ -35,6 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     @IBOutlet weak var detailedStatusMenuItem: NSMenuItem!
     @IBOutlet weak var copyOcLoginCommand: NSMenuItem!
     
+    let statusRefreshRate: TimeInterval = 5 // seconds
     var kubeadminPass: String!
     var apiEndpoint: String!
     var status: String = ""
@@ -64,13 +65,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             notificationAllowed = granted
             print(error?.localizedDescription ?? "Notification Request: No Error")
         })
+        
         DispatchQueue.global(qos: .background).async {
-            let status = clusterStatus()
-            self.status = status
-            DispatchQueue.main.async {
-                self.initializeMenus(status: status)
-            }
+            self.refreshStatusAndMenu()
         }
+        
+        Timer.scheduledTimer(timeInterval: statusRefreshRate, target: self, selector: #selector(refreshStatusAndMenu), userInfo: nil, repeats: true)
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -212,13 +212,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     
     func menuWillOpen(_ menu: NSMenu) {
         DispatchQueue.global(qos: .background).async {
-            let status = clusterStatus()
-            self.status = status
-            
-            DispatchQueue.main.async {
-                self.initializeMenus(status: status)
-            }
+            self.refreshStatusAndMenu()
         }
-        
+    }
+    
+    @objc func refreshStatusAndMenu() {
+        let status = clusterStatus()
+        self.status = status
+        DispatchQueue.main.async {
+            self.initializeMenus(status: status)
+        }
     }
 }


### PR DESCRIPTION
Previously the status changed only if the tray was clicked or at startup.

Polling is not ideal but this is the only mechanism we have right now.
Ideally, the daemon should notify the app of a status change.