### PR TITLE
Treat true|false as boolean and not as string

### DIFF
--- a/CodeReady Containers/KubeSwitch/YamlReader.swift
+++ b/CodeReady Containers/KubeSwitch/YamlReader.swift
@@ -1,4 +1,5 @@
-// Copyright (c) 2019 Sriram Narasimhan
+// Original work Copyright (c) 2019 Sriram Narasimhan
+// Modified work Copyright 2020 Red Hat
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -16,7 +17,7 @@ import os.log
 class YamlReader {
   func loadKubeConfig(yaml: String) -> KubeConfig {
     do {
-      let readYaml = try Yams.load(yaml: yaml, .basic)
+      let readYaml = try Yams.load(yaml: yaml)
       let yamlContent = readYaml != nil ? readYaml as! [String: Any] : [:]
       return KubeConfig(yamlContent: yamlContent)
     } catch {


### PR DESCRIPTION
KubeSwitch corrupts the .kube/config file.
Unexpected diff after switch:

```
4c4
<     insecure-skip-tls-verify: 'true'
---
>     insecure-skip-tls-verify: true
````

It triggers:
$ kubectl get pods
error: error loading config file "/Users/guillaumerose/.kube/config": v1.Config.Clusters: []v1.NamedCluster: v1.NamedCluster.Cluster: v1.Cluster.InsecureSkipTLSVerify: ReadBool: expect t or f, but found ", error found in #10 byte of ...|-verify":"true","ser|..., bigger context ...|lusters":[{"cluster":{"insecure-skip-tls-verify":"true","server":"https://api.crc.testing:6443"},"na|...