### PR TITLE
Remove force cast in KubeSwitch code

### DIFF
--- a/CodeReady Containers/KubeSwitch/KubeConfig.swift
+++ b/CodeReady Containers/KubeSwitch/KubeConfig.swift
@@ -19,8 +19,11 @@ class KubeConfig {
   }
 
   func currentContext() -> String {
-    return (self.yamlContent["current-context"] != nil)
-      ? self.yamlContent["current-context"] as! String : ""
+    if let ret =  self.yamlContent["current-context"] as? String {
+        return ret
+    } else {
+        return ""
+    }
   }
 
   func isCurrentContext(otherContextName: String) -> Bool {
@@ -28,18 +31,23 @@ class KubeConfig {
   }
 
   func contexts() -> [AnyObject] {
-    return (self.yamlContent["contexts"] != nil)
-      ? self.yamlContent["contexts"] as! [AnyObject] : []
+    if let ret =  self.yamlContent["contexts"] as? [AnyObject] {
+        return ret
+    } else {
+        return []
+    }
   }
 
   func contextNames() -> [String] {
     return self.contexts()
       .map {
-        $0 as! [String: Any]
+        $0 as? [String: Any]
       }
+      .compactMap { $0 }
       .map {
-        $0["name"] as! String
+        $0["name"] as? String
       }
+      .compactMap { $0 }
   }
 
   func changeContext(newContext: String) {

--- a/CodeReady Containers/KubeSwitch/YamlReader.swift
+++ b/CodeReady Containers/KubeSwitch/YamlReader.swift
@@ -18,8 +18,11 @@ class YamlReader {
   func loadKubeConfig(yaml: String) -> KubeConfig {
     do {
       let readYaml = try Yams.load(yaml: yaml)
-      let yamlContent = readYaml != nil ? readYaml as! [String: Any] : [:]
-      return KubeConfig(yamlContent: yamlContent)
+      if let ret = readYaml as? [String: Any] {
+        return KubeConfig(yamlContent: ret)
+      } else {
+        return KubeConfig(yamlContent: [:])
+      }
     } catch {
       os_log("Could not load yaml string as dictionary", type: .error)
       let errorDetails = "\(error)"


### PR DESCRIPTION
It avoids the app to crash if the kubeconfig file is unexpected.

Fixes #112 